### PR TITLE
fix : 컨테이너 텍스트 길이 조절

### DIFF
--- a/src/components/MainPage/RecentQuizContainer.jsx
+++ b/src/components/MainPage/RecentQuizContainer.jsx
@@ -34,7 +34,9 @@ const RecentQuizContainer = ({
             {!isHovered ? (
               <>
                 <div className="flex items-center leading-6 ml-[20px] mt-[16px] w-[196px] h-[72px] text-wrap  font-semibold text-neutralwhite text-[20px]">
-                  {noteName}
+                  {noteName.length > 25
+                    ? `${noteName.slice(0, 25)}...`
+                    : noteName}
                 </div>
               </>
             ) : (
@@ -43,7 +45,9 @@ const RecentQuizContainer = ({
                   <div className="flex flex-col justify-center">
                     <div className={`mt-[16px] ml-[20px]`}>
                       <div className=" flex leading-6 w-[196px] h-[72px] text-wrap font-semibold text-neutralwhite text-[20px]">
-                        {noteName}
+                        {noteName.length > 25
+                          ? `${noteName.slice(0, 25)}...`
+                          : noteName}
                       </div>
                     </div>
                     <div className="flex justify-center w-[300px] mt-4">

--- a/src/components/NoteStorePage/StoredNote.jsx
+++ b/src/components/NoteStorePage/StoredNote.jsx
@@ -76,8 +76,8 @@ const StoredNote = ({
           <div className="flex flex-col">
             <div className="mt-[16px] ml-[20px]">
               <div className=" flex items-center leading-6 w-[196px] h-[72px] text-wrap font-semibold text-neutralwhite text-[20px]">
-                {noteName.length > 20
-                  ? `${noteName.slice(0, 20)}...`
+                {noteName.length > 25
+                  ? `${noteName.slice(0, 25)}...`
                   : noteName}
               </div>
               <div className="flex gap-[8px] mt-[8px]">
@@ -145,7 +145,7 @@ const StoredNote = ({
           </div>
           {!isHovered && (
             <div className="flex items-center leading-6 ml-[20px] mt-[16px] w-[196px] h-[72px] text-wrap font-semibold text-neutralwhite text-[20px]">
-              {noteName.length > 20 ? `${noteName.slice(0, 20)}...` : noteName}
+              {noteName.length > 25 ? `${noteName.slice(0, 25)}...` : noteName}
             </div>
           )}
         </div>

--- a/src/components/QuizLabPage/QuizContainer.jsx
+++ b/src/components/QuizLabPage/QuizContainer.jsx
@@ -63,7 +63,9 @@ const QuizContainer = ({
           {!isHovered ? (
             <>
               <div className="flex items-center leading-6 ml-[20px] mt-[16px] w-[196px] h-[72px] text-wrap  font-semibold text-neutralwhite text-[20px]">
-                {noteName}
+                {noteName.length > 20
+                  ? `${noteName.slice(0, 25)}...`
+                  : noteName}
               </div>
             </>
           ) : (
@@ -72,7 +74,9 @@ const QuizContainer = ({
                 <div className="flex flex-col">
                   <div className={`mt-[16px] ml-[20px]`}>
                     <div className=" flex items-center leading-6 w-[196px] h-[72px] text-wrap font-semibold text-neutralwhite text-[20px]">
-                      {noteName}
+                      {noteName.length > 20
+                        ? `${noteName.slice(0, 25)}...`
+                        : noteName}
                     </div>
                     <div className="mt-[15px]">
                       <ResultTag


### PR DESCRIPTION
# 구현 기능
- 노트/퀴즈 컨테이너 내 텍스트 길이 조절

# 구현 상태
![image](https://github.com/user-attachments/assets/70cbf346-de0f-4f4e-a9f1-2b11986dcf99)
25자 이상 넘어가면 ...으로 보이도록

# 이슈 태그
- #49 
